### PR TITLE
fix 台語工程詞彙表 missing ⁿ and other mistake

### DIFF
--- a/nan-TW/taigi-kang-teng-su-lui-pio.txt
+++ b/nan-TW/taigi-kang-teng-su-lui-pio.txt
@@ -2,25 +2,25 @@
 詞彙表（sû-lūi-pió）
 塗水（thô-chúi）
 疊磚（thia̍p-chng）
-地繩線（tē-chîn-sòa）
+地繩線（tē-chîn-sòaⁿ）
 貼（tah）
-平坦（pên-thán）
+平坦（pêⁿ-thán | pîⁿ-thán）
 搭架（tah-kè）
 油漆（iû-chhat）
 釘枋模（tèng pang-bô）
-灌漿（koàn-chiun）
+灌漿（koàn-chiuⁿ）
 做裝潢（chò chong-hông）
 縛鐵仔（pa̍k thih-á）
 黏條仔（liâm tiâu-á）
-做水電（chò chúi-tiān）
+做水電（chò chúi-tiān | chòe chúi-tiān）
 抿石仔（bín chio̍h-á）
 反金（hoán-kim）
-磨石仔（bôachioh̍-á）
+磨石仔（bôa chioh̍-á）
 洗石仔（sé-chio̍h-á）
 斬石仔（chám-chio̍h-á）
-做地磚（chò tē-chng）
+做地磚（chò tē-chng|chòe tōe-chng）
 拍塗跤底（phah thô͘-kha-té）
-做防水（chò hông-chúi）
+做防水（chò hông-chúi | chòe hông-chúi）
 吊料（tiàu-liāu）
 夯料（giâ-liâu）
 人（lâng）
@@ -33,7 +33,7 @@
 抹塗跤（boah-thô͘-kha）
 抹柱仔（boah-thiāu-á）
 拍底（phah-té）
-搝線（giú-sòan）
+搝線（giú-sòaⁿ）
 斷壁（tnḡ-piah）
 剾壁（khau-piah）
 疊磚（thia̍p-chng）
@@ -116,10 +116,10 @@
 廊（lông）
 工地（kang-tē）
 鐵架（thih-kè）
-三角架（san-kak-kè） 
+三角架（saⁿ-kak-kè） 
 鐵枋（thih-pang）
 電篋仔（tiān-kheh-á）
-地繩線（tē-chîn-sòan）
+地繩線（tē-chîn-sòaⁿ）
 形容詞（hêng-lông-sû）
 好（hó）
 䆀（bái）


### PR DESCRIPTION
應該是鼻音 pêⁿ-thán|pîⁿ-thán
11 koàn-chiuⁿ
好像ⁿ鼻音都變成n了
18 磨石仔（bôachioh̍-á）->bôa chio̍h-á
118 ⁿ鼻音無去，三角架（san-kak-kè） ->saⁿ-kak-kè
5, 36, 122的線應該是sòa